### PR TITLE
Fix category creation in slug test

### DIFF
--- a/17/chapters/test.rst
+++ b/17/chapters/test.rst
@@ -120,7 +120,7 @@ Let's try adding another test, that ensures an appropriate slug line is created 
 			i.e. "Random Category String" -> "random-category-string"
 			"""
 
-			cat = cat('Random Category String')
+			cat = Category(name='Random Category String')
 			cat.save()
 			self.assertEqual(cat.slug, 'random-category-string')
 


### PR DESCRIPTION
Maybe you want to add, views and likes values.

cat = Category(name='Random Category String', views=0, likes=0)