### PR TITLE
Fix template and context in suggest_category view return

### DIFF
--- a/17/chapters/ajax.rst
+++ b/17/chapters/ajax.rst
@@ -195,7 +195,7 @@ Using the ``get_category_list`` function we can now create a view that returns t
 		
 		cat_list = get_category_list(8, starts_with)
 			
-		return render(request, 'rango/category_list.html', {'cat_list': cat_list })
+		return render(request, 'rango/cats.html', {'cats': cat_list })
 
 Note here we are re-using the ``rango/cats.html`` template :-). 
 


### PR DESCRIPTION
Add the correct render template and give the right context. I don't know if you want to maintain cat_list or use only cats, so I only change the last step and maintain cat_list in the rest of the code.