### PR TITLE
Fix missing JQuery code in 19.4.1 - Fixes #165

### DIFF
--- a/17/chapters/ajax.rst
+++ b/17/chapters/ajax.rst
@@ -268,7 +268,7 @@ HTML Template code:
 
 JQuery code:
 
-.. code-block: javascript
+.. code-block:: javascript
 
 	$('.rango-add').click(function(){
 	    var catid = $(this).attr("data-catid");


### PR DESCRIPTION
Missing ':' hid the JQuery code example.