### PR TITLE
properly end a `` tag and other

### DIFF
--- a/17/chapters/bootstrap.rst
+++ b/17/chapters/bootstrap.rst
@@ -100,7 +100,7 @@ The New Base Template
 	</html>
 
 
-If you take a close look at the dashboard html source, you'll notice it has a lot of structure in it created by a series of ``<div>`` tags. Essentially the page is broken into two parts - the top navigation bar and the main pane which are denoted by the two ``<div class="container-fluid">``s. In the nav bar section, we have injected all the links to the different parts of our website. Inside the main pane, there are two columns, one for the ``side_block``, and the other for the ``body_block``.
+If you take a close look at the dashboard html source, you'll notice it has a lot of structure in it created by a series of ``<div>`` tags. Essentially the page is broken into two parts - the top navigation bar and the main pane which are denoted by the two ``<div class="container-fluid">`` tags. In the nav bar section, we have injected all the links to the different parts of our website. Inside the main pane, there are two columns, one for the ``side_block``, and the other for the ``body_block``.
 
 
 Quick Style Change

--- a/17/chapters/test.rst
+++ b/17/chapters/test.rst
@@ -104,7 +104,7 @@ Now lets run test:
 	
 
 
-As we can see this test fails. This is because the model does not check whether the value is less than zero or not. Since we really want to ensure that the values are non-zero, we will need to update the model, to ensure that this requirement is fulfilled. Do this now by adding some code to the Catgegory models, ``save()`` method, that checks the value of views, and updates it accordingly.
+As we can see this test fails. This is because the model does not check whether the value is less than zero or not. Since we really want to ensure that the values are non-zero, we will need to update the model, to ensure that this requirement is fulfilled. Do this now by adding some code to the Category models, ``save()`` method, that checks the value of views, and updates it accordingly.
 
 
 Once you have updated your model, you can now re-run the test, and see if your code now passes it. If not, try again.

--- a/17/chapters/test.rst
+++ b/17/chapters/test.rst
@@ -131,7 +131,7 @@ Does your code still work?
 
 Testing Views
 -------------
-So far we have writtent tests that focus on ensuring the integrity of the data housed in the models. Django also provides testing mechanisms to test views. It does this with a mock client, that internally makes a calls a django view via the url. In the test you have access to the response (including the html) and the context dictionary. 
+So far we have writtent tests that focus on ensuring the integrity of the data housed in the models. Django also provides testing mechanisms to test views. It does this with a mock client, that internally calls a django view via the url. In the test you have access to the response (including the html) and the context dictionary. 
 
 Let's create a test that checks that when the index page loads, it displays the message that ``There are no categories present``, when the Category model is empty. 
 

--- a/17/chapters/test.rst
+++ b/17/chapters/test.rst
@@ -120,7 +120,7 @@ Let's try adding another test, that ensures an appropriate slug line is created 
 			i.e. "Random Category String" -> "random-category-string"
 			"""
 
-			cat = cat('Random Category String')
+			cat = Category('Random Category String')
 			cat.save()
 			self.assertEqual(cat.slug, 'random-category-string')
 


### PR DESCRIPTION
The closing `` tag must be followed by a dot or a space, otherwise
we don't get the expected result.